### PR TITLE
fix: address properties with BMECat namespace prefix

### DIFF
--- a/src/Nodes/Address.php
+++ b/src/Nodes/Address.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Naugrim\OpenTrans\Nodes;
+
+use JMS\Serializer\Annotation as Serializer;
+
+class Address extends \Naugrim\BMEcat\Nodes\Address
+{
+    /**
+     * @Serializer\SerializedName("bme:NAME")
+     */
+    protected $name;
+
+    /**
+     * @Serializer\SerializedName("bme:NAME2")
+     */
+    protected $name2;
+
+    /**
+     * @Serializer\SerializedName("bme:NAME3")
+     */
+    protected $name3;
+
+    /**
+     * @Serializer\SerializedName("bme:DEPARTMENT")
+     */
+    protected $department;
+
+    /**
+     * @Serializer\SerializedName("CONTACT_DETAILS")
+     * @Serializer\Type("Naugrim\OpenTrans\Nodes\ContactDetails")
+     */
+    protected $contactDetails;
+
+    /**
+     * @Serializer\SerializedName("bme:STREET")
+     */
+    protected $street;
+
+    /**
+     * @Serializer\SerializedName("bme:ZIP")
+     */
+    protected $zip;
+
+    /**
+     * @Serializer\SerializedName("bme:BOXNO")
+     */
+    protected $boxno;
+
+    /**
+     * @Serializer\SerializedName("bme:ZIPBOX")
+     */
+    protected $zipbox;
+
+    /**
+     * @Serializer\SerializedName("bme:CITY")
+     */
+    protected $city;
+
+    /**
+     * @Serializer\SerializedName("bme:COUNTRY")
+     */
+    protected $country;
+
+    /**
+     * @Serializer\SerializedName("bme:COUNTRY_CODED")
+     */
+    protected $countryCoded;
+
+    /**
+     * @Serializer\SerializedName("bme:VAT_ID")
+     */
+    protected $vatId;
+
+    /**
+     * @Serializer\SerializedName("bme:PHONE")
+     */
+    protected $phone;
+
+    /**
+     * @Serializer\SerializedName("bme:FAX")
+     */
+    protected $fax;
+
+    /**
+     * @Serializer\SerializedName("bme:EMAIL")
+     */
+    protected $email;
+
+    /**
+     * @Serializer\SerializedName("bme:PUBLIC_KEY")
+     */
+    protected $publicKey;
+
+    /**
+     * @Serializer\SerializedName("bme:URL")
+     */
+    protected $url;
+
+    /**
+     * @Serializer\SerializedName("bme:ADDRESS_REMARKS")
+     */
+    protected $addressRemarks;
+}

--- a/src/Nodes/ContactDetails.php
+++ b/src/Nodes/ContactDetails.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Naugrim\OpenTrans\Nodes;
+
+use JMS\Serializer\Annotation as Serializer;
+use Naugrim\BMEcat\Nodes\Contact\Details;
+
+class ContactDetails extends Details
+{
+    /**
+     * @Serializer\SerializedName("bme:CONTACT_ID")
+     */
+    protected $id;
+
+    /**
+     * @Serializer\SerializedName("bme:CONTACT_NAME")
+     */
+    protected $name;
+
+    /**
+     * @Serializer\SerializedName("bme:FIRST_NAME")
+     */
+    protected $firstName;
+
+    /**
+     * @Serializer\SerializedName("bme:TITLE")
+     */
+    protected $title;
+
+    /**
+     * @Serializer\SerializedName("bme:ACADEMIC_TITLE")
+     */
+    protected $academicTitle;
+
+    /**
+     * @Serializer\SerializedName("bme:CONTACT_ROLE")
+     */
+    protected $role;
+
+    /**
+     * @Serializer\SerializedName("bme:CONTACT_DESCRIPTION")
+     */
+    protected $description;
+
+    /**
+     * @Serializer\SerializedName("bme:PHONE")
+     */
+    protected $phone;
+
+    /**
+     * @Serializer\SerializedName("bme:FAX")
+     *
+     */
+    protected $fax;
+
+    /**
+     * @Serializer\SerializedName("bme:URL")
+     *
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @Serializer\SerializedName("bme:EMAILS")
+     */
+    protected $emails;
+}

--- a/src/Nodes/Party.php
+++ b/src/Nodes/Party.php
@@ -3,7 +3,6 @@
 namespace Naugrim\OpenTrans\Nodes;
 
 use JMS\Serializer\Annotation as Serializer;
-use Naugrim\BMEcat\Nodes\Address;
 use Naugrim\BMEcat\Nodes\Contracts\NodeInterface;
 
 /**
@@ -30,7 +29,7 @@ class Party implements NodeInterface
 
     /**
      * @Serializer\Expose
-     * @Serializer\Type("Naugrim\BMEcat\Nodes\Address")
+     * @Serializer\Type("Naugrim\OpenTrans\Nodes\Address")
      * @Serializer\SerializedName ("ADDRESS")
      * @var Address
      */

--- a/tests/Nodes/OrderTest.php
+++ b/tests/Nodes/OrderTest.php
@@ -90,6 +90,71 @@ class OrderTest extends TestCase
                 ]
             ],
             [
+                'file' => '/../assets/minimal_valid_order_with_address.xml',
+                'data' => [
+                    'header' => [
+                        'info' => [
+                            'id' => 'order-id-1',
+                            'date' => (new DateTimeImmutable('2020-01-27'))->format('Y-m-d'),
+                            'parties' => [
+                                [
+                                    'id' => ['value' => 'org.de.supplier']
+                                ],
+                                [
+                                    'id' => ['value' => 'org.de.buyer', 'type' => 'buyer'],
+                                    'address' => [
+                                        'name' => 'Someone',
+                                        'name2' => 'Else',
+                                        'zip' => '98765',
+                                        'street' => 'Some street',
+                                        'city' => 'Somewhere',
+                                        'country' => 'Germany',
+                                        'countryCoded' => 'DE',
+                                        'contactDetails' => [
+                                            'id' => '1234-098765',
+                                            'firstName' => 'John',
+                                            'name' => 'Doe',
+                                            'title' => 'Miss',
+                                            'academicTitle' => 'Dr',
+                                            'phone' => [
+                                                'value' => '+49 321 654987',
+                                                'type' => 'mobile'
+                                            ]
+                                        ],
+                                        'phone' => [
+                                            'value' => '+49 123 456789 - 0'
+                                        ]
+                                    ]
+                                ],
+                            ],
+                            'partiesReference' => [
+                                'buyerIdRef' => [
+                                    'value' => 'org.de.buyer',
+                                ],
+                                'supplierIdRef' => [
+                                    'value' => 'org.de.buyer',
+                                ],
+                            ]
+                        ]
+                    ],
+                    'items' => [
+                        [
+                            'lineItemId' => 'line-item-id-1',
+                            'productId' => [
+                                'supplierPid' => [
+                                    'value' => 'product-number-1'
+                                ]
+                            ],
+                            'quantity' => 10,
+                            'orderUnit' => 'C62',
+                        ]
+                    ],
+                    'summary' => [
+                        'totalItemNum' => 1,
+                    ]
+                ]
+            ],
+            [
                 'file' => '/../assets/minimal_valid_order.xml',
                 'data' => [
                     'header' => [

--- a/tests/assets/minimal_valid_order_with_address.xml
+++ b/tests/assets/minimal_valid_order_with_address.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ORDER xmlns="http://www.opentrans.org/XMLSchema/2.1" type="standard" xmlns:bme="http://www.bmecat.org/bmecat/2005" version="2.1">
+  <ORDER_HEADER>
+    <ORDER_INFO>
+      <ORDER_ID><![CDATA[order-id-1]]></ORDER_ID>
+      <ORDER_DATE><![CDATA[2020-01-27]]></ORDER_DATE>
+      <PARTIES>
+        <PARTY>
+          <bme:PARTY_ID><![CDATA[org.de.supplier]]></bme:PARTY_ID>
+        </PARTY>
+        <PARTY>
+          <bme:PARTY_ID type="buyer"><![CDATA[org.de.buyer]]></bme:PARTY_ID>
+          <ADDRESS>
+            <bme:NAME><![CDATA[Someone]]></bme:NAME>
+            <bme:NAME2><![CDATA[Else]]></bme:NAME2>
+            <CONTACT_DETAILS>
+              <bme:CONTACT_ID><![CDATA[1234-098765]]></bme:CONTACT_ID>
+              <bme:CONTACT_NAME><![CDATA[Doe]]></bme:CONTACT_NAME>
+              <bme:FIRST_NAME><![CDATA[John]]></bme:FIRST_NAME>
+              <bme:TITLE><![CDATA[Miss]]></bme:TITLE>
+              <bme:ACADEMIC_TITLE><![CDATA[Dr]]></bme:ACADEMIC_TITLE>
+              <bme:PHONE type="mobile"><![CDATA[+49 321 654987]]></bme:PHONE>
+            </CONTACT_DETAILS>
+            <bme:STREET><![CDATA[Some street]]></bme:STREET>
+            <bme:ZIP><![CDATA[98765]]></bme:ZIP>
+            <bme:CITY><![CDATA[Somewhere]]></bme:CITY>
+            <bme:COUNTRY><![CDATA[Germany]]></bme:COUNTRY>
+            <bme:COUNTRY_CODED><![CDATA[DE]]></bme:COUNTRY_CODED>
+            <bme:PHONE><![CDATA[+49 123 456789 - 0]]></bme:PHONE>
+          </ADDRESS>
+        </PARTY>
+      </PARTIES>
+      <ORDER_PARTIES_REFERENCE>
+        <bme:BUYER_IDREF><![CDATA[org.de.buyer]]></bme:BUYER_IDREF>
+        <bme:SUPPLIER_IDREF><![CDATA[org.de.buyer]]></bme:SUPPLIER_IDREF>
+      </ORDER_PARTIES_REFERENCE>
+    </ORDER_INFO>
+  </ORDER_HEADER>
+  <ORDER_ITEM_LIST>
+    <ORDER_ITEM>
+      <LINE_ITEM_ID><![CDATA[line-item-id-1]]></LINE_ITEM_ID>
+      <PRODUCT_ID>
+        <bme:SUPPLIER_PID><![CDATA[product-number-1]]></bme:SUPPLIER_PID>
+      </PRODUCT_ID>
+      <QUANTITY>10.0</QUANTITY>
+      <bme:ORDER_UNIT><![CDATA[C62]]></bme:ORDER_UNIT>
+    </ORDER_ITEM>
+  </ORDER_ITEM_LIST>
+  <ORDER_SUMMARY>
+    <TOTAL_ITEM_NUM>1</TOTAL_ITEM_NUM>
+  </ORDER_SUMMARY>
+</ORDER>


### PR DESCRIPTION
Add Address and ContactDetails classes in Naugrim\OpenTrans\Nodes namespace in order to override XML Serializer annotations for meeting OpenTrans Spec requirements

resolves: #5