### PR TITLE
fix: address, contact detail and email properties with BMECat namespace prefix 

### DIFF
--- a/src/Nodes/Address.php
+++ b/src/Nodes/Address.php
@@ -1,106 +1,393 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Naugrim\OpenTrans\Nodes;
 
 use JMS\Serializer\Annotation as Serializer;
+use Naugrim\BMEcat\Nodes\Contracts\NodeInterface;
+use Naugrim\BMEcat\Nodes\Crypto\PublicKey;
+use Naugrim\BMEcat\Nodes\Fax;
+use Naugrim\BMEcat\Nodes\Phone;
+use Naugrim\OpenTrans\Nodes\Contact\Details;
 
-class Address extends \Naugrim\BMEcat\Nodes\Address
+class Address implements NodeInterface
 {
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:NAME")
+     *
+     * @var string
      */
     protected $name;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:NAME2")
+     *
+     * @var string
      */
     protected $name2;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:NAME3")
+     *
+     * @var string
      */
     protected $name3;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:DEPARTMENT")
+     *
+     * @var string
      */
     protected $department;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\OpenTrans\Nodes\Contact\Details")
      * @Serializer\SerializedName("CONTACT_DETAILS")
-     * @Serializer\Type("Naugrim\OpenTrans\Nodes\ContactDetails")
+     *
+     * @var Details
      */
     protected $contactDetails;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:STREET")
+     *
+     * @var string
      */
     protected $street;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:ZIP")
+     *
+     * @var string
      */
     protected $zip;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:BOXNO")
+     *
+     * @var string
      */
     protected $boxno;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:ZIPBOX")
+     *
+     * @var string
      */
     protected $zipbox;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:CITY")
+     *
+     * @var string
      */
     protected $city;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:COUNTRY")
+     *
+     * @var string
      */
     protected $country;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:COUNTRY_CODED")
+     *
+     * @var string
      */
     protected $countryCoded;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:VAT_ID")
+     *
+     * @var string
      */
     protected $vatId;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\BMEcat\Nodes\Phone")
      * @Serializer\SerializedName("bme:PHONE")
+     *
+     * @var Phone
      */
     protected $phone;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\BMEcat\Nodes\Fax")
      * @Serializer\SerializedName("bme:FAX")
+     *
+     * @var Fax
      */
     protected $fax;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:EMAIL")
+     *
+     * @var string
      */
     protected $email;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\BMEcat\Nodes\Crypto\PublicKey")
      * @Serializer\SerializedName("bme:PUBLIC_KEY")
+     *
+     * @var PublicKey
      */
     protected $publicKey;
 
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:URL")
+     *
+     * @var string
      */
     protected $url;
-
+    
     /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
      * @Serializer\SerializedName("bme:ADDRESS_REMARKS")
+     *
+     * @var string
      */
     protected $addressRemarks;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): Address
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getName2(): string
+    {
+        return $this->name2;
+    }
+
+    public function setName2(string $name2): Address
+    {
+        $this->name2 = $name2;
+        return $this;
+    }
+
+    public function getName3(): string
+    {
+        return $this->name3;
+    }
+
+    public function setName3(string $name3): Address
+    {
+        $this->name3 = $name3;
+        return $this;
+    }
+
+    public function getDepartment(): string
+    {
+        return $this->department;
+    }
+
+    public function setDepartment(string $department): Address
+    {
+        $this->department = $department;
+        return $this;
+    }
+
+    public function getContactDetails(): Details
+    {
+        return $this->contactDetails;
+    }
+
+    public function setContactDetails(Details $contactDetails): Address
+    {
+        $this->contactDetails = $contactDetails;
+        return $this;
+    }
+
+    public function getStreet(): string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(string $street): Address
+    {
+        $this->street = $street;
+        return $this;
+    }
+
+    public function getZip(): string
+    {
+        return $this->zip;
+    }
+
+    public function setZip(string $zip): Address
+    {
+        $this->zip = $zip;
+        return $this;
+    }
+
+    public function getBoxno(): string
+    {
+        return $this->boxno;
+    }
+
+    public function setBoxno(string $boxno): Address
+    {
+        $this->boxno = $boxno;
+        return $this;
+    }
+
+    public function getZipbox(): string
+    {
+        return $this->zipbox;
+    }
+
+    public function setZipbox(string $zipbox): Address
+    {
+        $this->zipbox = $zipbox;
+        return $this;
+    }
+
+    public function getCity(): string
+    {
+        return $this->city;
+    }
+
+    public function setCity(string $city): Address
+    {
+        $this->city = $city;
+        return $this;
+    }
+
+    public function getCountry(): string
+    {
+        return $this->country;
+    }
+
+    public function setCountry(string $country): Address
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    public function getCountryCoded(): string
+    {
+        return $this->countryCoded;
+    }
+
+    public function setCountryCoded(string $countryCoded): Address
+    {
+        $this->countryCoded = $countryCoded;
+        return $this;
+    }
+
+    public function getVatId(): string
+    {
+        return $this->vatId;
+    }
+
+    public function setVatId(string $vatId): Address
+    {
+        $this->vatId = $vatId;
+        return $this;
+    }
+
+    public function getPhone(): Phone
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(Phone $phone): Address
+    {
+        $this->phone = $phone;
+        return $this;
+    }
+
+    public function getFax(): Fax
+    {
+        return $this->fax;
+    }
+
+    public function setFax(Fax $fax): Address
+    {
+        $this->fax = $fax;
+        return $this;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): Address
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    public function getPublicKey(): PublicKey
+    {
+        return $this->publicKey;
+    }
+
+    public function setPublicKey(PublicKey $publicKey): Address
+    {
+        $this->publicKey = $publicKey;
+        return $this;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): Address
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    public function getAddressRemarks(): string
+    {
+        return $this->addressRemarks;
+    }
+
+    public function setAddressRemarks(string $addressRemarks): Address
+    {
+        $this->addressRemarks = $addressRemarks;
+        return $this;
+    }
 }

--- a/src/Nodes/Contact/Details.php
+++ b/src/Nodes/Contact/Details.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Naugrim\OpenTrans\Nodes\Contact;
+
+use JMS\Serializer\Annotation as Serializer;
+use Naugrim\BMEcat\Nodes\Contact\Role;
+use Naugrim\BMEcat\Nodes\Contracts\NodeInterface;
+use Naugrim\BMEcat\Nodes\Fax;
+use Naugrim\BMEcat\Nodes\Phone;
+use Naugrim\OpenTrans\Nodes\Emails;
+
+class Details implements NodeInterface
+{
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:CONTACT_ID")
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:CONTACT_NAME")
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:FIRST_NAME")
+     *
+     * @var string
+     */
+    protected $firstName;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:TITLE")
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:ACADEMIC_TITLE")
+     *
+     * @var string
+     */
+    protected $academicTitle;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\BMEcat\Nodes\Contact\Role")
+     * @Serializer\SerializedName("bme:CONTACT_ROLE")
+     *
+     * @var Role
+     */
+    protected $role;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:CONTACT_DESCRIPTION")
+     *
+     * @var string
+     */
+    protected $description;
+    
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\BMEcat\Nodes\Phone")
+     * @Serializer\SerializedName("bme:PHONE")
+     *
+     * @var Phone
+     */
+    protected $phone;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\BMEcat\Nodes\Fax")
+     * @Serializer\SerializedName("bme:FAX")
+     *
+     * @var Fax
+     */
+    protected $fax;
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:URL")
+     *
+     * @var string
+     */
+    protected $url;
+    
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("Naugrim\OpenTrans\Nodes\Emails")
+     * @Serializer\SerializedName("bme:EMAILS")
+     *
+     * @var Emails
+     */
+    protected $emails;
+
+
+    /**
+     * @return string
+     */
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return Details
+     */
+    public function setId(string $id): Details
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return Details
+     */
+    public function setName(string $name): Details
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @param string $firstName
+     * @return Details
+     */
+    public function setFirstName(string $firstName): Details
+    {
+        $this->firstName = $firstName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     * @return Details
+     */
+    public function setTitle(string $title): Details
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAcademicTitle(): string
+    {
+        return $this->academicTitle;
+    }
+
+    /**
+     * @param string $academicTitle
+     * @return Details
+     */
+    public function setAcademicTitle(string $academicTitle): Details
+    {
+        $this->academicTitle = $academicTitle;
+        return $this;
+    }
+
+    /**
+     * @return Role
+     */
+    public function getRole(): Role
+    {
+        return $this->role;
+    }
+
+    /**
+     * @param Role $role
+     * @return Details
+     */
+    public function setRole(Role $role): Details
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     * @return Details
+     */
+    public function setDescription(string $description): Details
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @return Phone
+     */
+    public function getPhone(): Phone
+    {
+        return $this->phone;
+    }
+
+    /**
+     * @param Phone $phone
+     * @return Details
+     */
+    public function setPhone(Phone $phone): Details
+    {
+        $this->phone = $phone;
+        return $this;
+    }
+
+    /**
+     * @return Fax
+     */
+    public function getFax(): Fax
+    {
+        return $this->fax;
+    }
+
+    /**
+     * @param Fax $fax
+     * @return Details
+     */
+    public function setFax(Fax $fax): Details
+    {
+        $this->fax = $fax;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param string $url
+     * @return Details
+     */
+    public function setUrl(string $url): Details
+    {
+        $this->url = $url;
+        return $this;
+    }
+
+    public function getEmails(): Emails
+    {
+        return $this->emails;
+    }
+
+    public function setEmails(Emails $emails): Details
+    {
+        $this->emails = $emails;
+        return $this;
+    }
+}

--- a/src/Nodes/ContactDetails.php
+++ b/src/Nodes/ContactDetails.php
@@ -1,69 +1,12 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Naugrim\OpenTrans\Nodes;
 
-use JMS\Serializer\Annotation as Serializer;
-use Naugrim\BMEcat\Nodes\Contact\Details;
+use Naugrim\OpenTrans\Nodes\Contact\Details;
 
+/**
+ * @deprecated use Contact\Details
+ */
 class ContactDetails extends Details
 {
-    /**
-     * @Serializer\SerializedName("bme:CONTACT_ID")
-     */
-    protected $id;
-
-    /**
-     * @Serializer\SerializedName("bme:CONTACT_NAME")
-     */
-    protected $name;
-
-    /**
-     * @Serializer\SerializedName("bme:FIRST_NAME")
-     */
-    protected $firstName;
-
-    /**
-     * @Serializer\SerializedName("bme:TITLE")
-     */
-    protected $title;
-
-    /**
-     * @Serializer\SerializedName("bme:ACADEMIC_TITLE")
-     */
-    protected $academicTitle;
-
-    /**
-     * @Serializer\SerializedName("bme:CONTACT_ROLE")
-     */
-    protected $role;
-
-    /**
-     * @Serializer\SerializedName("bme:CONTACT_DESCRIPTION")
-     */
-    protected $description;
-
-    /**
-     * @Serializer\SerializedName("bme:PHONE")
-     */
-    protected $phone;
-
-    /**
-     * @Serializer\SerializedName("bme:FAX")
-     *
-     */
-    protected $fax;
-
-    /**
-     * @Serializer\SerializedName("bme:URL")
-     *
-     * @var string
-     */
-    protected $url;
-
-    /**
-     * @Serializer\SerializedName("bme:EMAILS")
-     */
-    protected $emails;
 }

--- a/src/Nodes/Emails.php
+++ b/src/Nodes/Emails.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Naugrim\OpenTrans\Nodes;
+
+use JMS\Serializer\Annotation as Serializer;
+use Naugrim\BMEcat\Builder\NodeBuilder;
+use Naugrim\BMEcat\Exception\InvalidSetterException;
+use Naugrim\BMEcat\Exception\UnknownKeyException;
+use Naugrim\BMEcat\Nodes\Contracts\NodeInterface;
+use Naugrim\BMEcat\nodes\Crypto\PublicKey;
+
+class Emails implements NodeInterface
+{
+    /**
+     * @Serializer\Expose
+     * @Serializer\Type("string")
+     * @Serializer\SerializedName("bme:EMAIL")
+     *
+     * @var string
+     */
+    protected $email = '';
+
+    /**
+     * @Serializer\Expose
+     * @Serializer\SerializedName("bme:PUBLIC_KEY")
+     * @Serializer\Type("array<Naugrim\BMEcat\Nodes\Crypto\PublicKey>")
+     * @Serializer\XmlList(inline = "true")
+     *
+     * @var PublicKey[]
+     */
+    protected $publicKeys = [];
+
+    /**
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     * @return Emails
+     */
+    public function setEmail(string $email): Emails
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * @return PublicKey[]
+     */
+    public function getPublicKeys(): array
+    {
+        return $this->publicKeys;
+    }
+
+    /**
+     * @param PublicKey[] $publicKeys
+     * @return Emails
+     * @throws InvalidSetterException
+     * @throws UnknownKeyException
+     */
+    public function setPublicKeys(array $publicKeys): Emails
+    {
+        $this->publicKeys = [];
+        foreach ($publicKeys as $publicKey) {
+            if (!$publicKey instanceof PublicKey) {
+                $publicKey = NodeBuilder::fromArray($publicKey, new PublicKey());
+            }
+            $this->addPublicKey($publicKey);
+        }
+        return $this;
+    }
+
+    /**
+     * @param PublicKey $publicKey
+     * @return Emails
+     */
+    public function addPublicKey(PublicKey $publicKey): Emails
+    {
+        $this->publicKeys[] = $publicKey;
+        return $this;
+    }
+}

--- a/tests/Nodes/OrderTest.php
+++ b/tests/Nodes/OrderTest.php
@@ -29,7 +29,11 @@ class OrderTest extends TestCase
     public function testOrder(string $file, array $data): void
     {
         $node = NodeBuilder::fromArray($data, new Order());
-        $xml = $this->serializer->serialize($node, 'xml');
+        try {
+            $xml = $this->serializer->serialize($node, 'xml');
+        } catch (\Throwable $exception) {
+            $this->fail($exception->getMessage());
+        }
 
         $this->assertEquals(file_get_contents(__DIR__ . $file), $xml);
         $this->assertTrue(SchemaValidator::isValid($xml, '2.1'));
@@ -38,6 +42,64 @@ class OrderTest extends TestCase
     public function provideOrderData(): array
     {
         return [
+            [
+                'file' => '/../assets/minimal_valid_order_with_contactdetails.xml',
+                'data' => [
+                    'header' => [
+                        'info' => [
+                            'id' => 'order-id-1',
+                            'date' => (new DateTimeImmutable('2020-01-27'))->format('Y-m-d'),
+                            'parties' => [
+                                [
+                                    'id' => ['type' => 'supplier_specific', 'value' => 'supplier ID'],
+                                    'role' => ['role' => 'supplier']
+                                ],
+                                [
+                                    'id' => ['value' => 'org.de.buyer', 'type' => 'buyer'],
+                                    'address' => [
+                                        'name' => 'Test Example',
+                                        'contactDetails' => [
+                                            'name' => 'Example',
+                                            'firstName' => 'Test',
+                                            'emails' => [
+                                                'email' => 'test@example.com'
+                                            ],
+                                        ],
+                                        'street' => 'Testweg',
+                                        'zip' => '42',
+                                        'city' => 'Springfield',
+                                        'country' => 'DE',
+                                        'email' => 'test@example.com',
+                                    ]
+                                ],
+                            ],
+                            'partiesReference' => [
+                                'buyerIdRef' => [
+                                    'value' => 'org.de.buyer',
+                                ],
+                                'supplierIdRef' => [
+                                    'value' => 'org.de.buyer',
+                                ],
+                            ]
+                        ]
+                    ],
+                    'items' => [
+                        [
+                            'lineItemId' => 'line-item-id-1',
+                            'productId' => [
+                                'supplierPid' => [
+                                    'value' => 'product-number-1'
+                                ]
+                            ],
+                            'quantity' => 10,
+                            'orderUnit' => 'C62',
+                        ]
+                    ],
+                    'summary' => [
+                        'totalItemNum' => 1,
+                    ]
+                ]
+            ],
             [
                 'file' => '/../assets/minimal_valid_order_with_udx.xml',
                 'data' => [

--- a/tests/assets/minimal_valid_order_with_contactdetails.xml
+++ b/tests/assets/minimal_valid_order_with_contactdetails.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ORDER xmlns="http://www.opentrans.org/XMLSchema/2.1" type="standard" xmlns:bme="http://www.bmecat.org/bmecat/2005" version="2.1">
+  <ORDER_HEADER>
+    <ORDER_INFO>
+      <ORDER_ID><![CDATA[order-id-1]]></ORDER_ID>
+      <ORDER_DATE><![CDATA[2020-01-27]]></ORDER_DATE>
+      <PARTIES>
+        <PARTY>
+          <bme:PARTY_ID type="supplier_specific"><![CDATA[supplier ID]]></bme:PARTY_ID>
+          <PARTY_ROLE><![CDATA[supplier]]></PARTY_ROLE>
+        </PARTY>
+        <PARTY>
+          <bme:PARTY_ID type="buyer"><![CDATA[org.de.buyer]]></bme:PARTY_ID>
+          <ADDRESS>
+            <bme:NAME><![CDATA[Test Example]]></bme:NAME>
+            <CONTACT_DETAILS>
+              <bme:CONTACT_NAME><![CDATA[Example]]></bme:CONTACT_NAME>
+              <bme:FIRST_NAME><![CDATA[Test]]></bme:FIRST_NAME>
+              <bme:EMAILS>
+                <bme:EMAIL><![CDATA[test@example.com]]></bme:EMAIL>
+              </bme:EMAILS>
+            </CONTACT_DETAILS>
+            <bme:STREET><![CDATA[Testweg]]></bme:STREET>
+            <bme:ZIP><![CDATA[42]]></bme:ZIP>
+            <bme:CITY><![CDATA[Springfield]]></bme:CITY>
+            <bme:COUNTRY><![CDATA[DE]]></bme:COUNTRY>
+            <bme:EMAIL><![CDATA[test@example.com]]></bme:EMAIL>
+          </ADDRESS>
+        </PARTY>
+      </PARTIES>
+      <ORDER_PARTIES_REFERENCE>
+        <bme:BUYER_IDREF><![CDATA[org.de.buyer]]></bme:BUYER_IDREF>
+        <bme:SUPPLIER_IDREF><![CDATA[org.de.buyer]]></bme:SUPPLIER_IDREF>
+      </ORDER_PARTIES_REFERENCE>
+    </ORDER_INFO>
+  </ORDER_HEADER>
+  <ORDER_ITEM_LIST>
+    <ORDER_ITEM>
+      <LINE_ITEM_ID><![CDATA[line-item-id-1]]></LINE_ITEM_ID>
+      <PRODUCT_ID>
+        <bme:SUPPLIER_PID><![CDATA[product-number-1]]></bme:SUPPLIER_PID>
+      </PRODUCT_ID>
+      <QUANTITY>10.0</QUANTITY>
+      <bme:ORDER_UNIT><![CDATA[C62]]></bme:ORDER_UNIT>
+    </ORDER_ITEM>
+  </ORDER_ITEM_LIST>
+  <ORDER_SUMMARY>
+    <TOTAL_ITEM_NUM>1</TOTAL_ITEM_NUM>
+  </ORDER_SUMMARY>
+</ORDER>


### PR DESCRIPTION
Add Emails, Address and ContactDetails classes in Naugrim\OpenTrans\Nodes namespace in order to override XML Serializer annotations for meeting OpenTrans Spec requirements

resolves: #7 