### PR TITLE
Remove maximumNumberOfProcesses limitation to keep analysis fast on modern computers.

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -11,9 +11,6 @@ parameters:
     param_type: 98
     property_type: 100
     print_suggestions: true
-  parallel:
-    # this should be LESS than you total number of cores to prevent clogging your system
-    maximumNumberOfProcesses: 2
   tmpDir: .phpstan
   # put all "your" paths here
   # this generally is "src" and "tests"


### PR DESCRIPTION
In CI PHPStan will automatically the maximum number of CPUs to use